### PR TITLE
add default value for $strIcon

### DIFF
--- a/src/Resources/contao/forms/FormCalendarField.php
+++ b/src/Resources/contao/forms/FormCalendarField.php
@@ -87,6 +87,9 @@ class FormCalendarField extends \FormTextField
     }
 
     if ($this->dateImage) {
+      
+      $strIcon = '';
+      
       if (\Validator::isUuid($this->dateImageSRC)) {
         $objModel = \FilesModel::findByUuid($this->dateImageSRC);
 


### PR DESCRIPTION
In PHP 8, if the icon doesn't exist, a warning is triggered, because $strIcon is never set.